### PR TITLE
Convert RGB and RGBA to NamedTuple classes so that they can be checked

### DIFF
--- a/ansiscape/types/rgb.py
+++ b/ansiscape/types/rgb.py
@@ -1,5 +1,8 @@
-from typing import Tuple
+from typing import NamedTuple
 
 # Represents the red, green and blue (RGB) aspects of a colour. Each component
 # is described by a float from 0.0 to 1.0.
-RGB = Tuple[float, float, float]
+class RGB(NamedTuple):
+    red: float
+    green: float
+    blue: float

--- a/ansiscape/types/rgba.py
+++ b/ansiscape/types/rgba.py
@@ -1,7 +1,9 @@
-from typing import Tuple
-
-# ALPHA = Union[Literal[0], Literal[1]]
+from typing import NamedTuple
 
 # Represents the red, green, blue and alpha aspects of a colour. Each component
 # is described by a float from 0.0 to 1.0.
-RGBA = Tuple[float, float, float, float]
+class RGBA(NamedTuple):
+    red: float
+    green: float
+    blue: float
+    alpha: float


### PR DESCRIPTION
Changed from using typing.Tuple to typing.NamedTuple so RGB and RGBA are now classes which means they can be checked through `isinstance()` calls, which typing aliases cannot.

I wasn't able to get the entire build environment going locally (something kept complaining about version -1.-1.-1 and I couldn't figure out what). I did manually install pytest and run the tests though and I don't think I broke anything.